### PR TITLE
Fix TF import since OTBTF tricks module removal

### DIFF
--- a/code/network.py
+++ b/code/network.py
@@ -19,8 +19,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
-from tricks import tf
 from functools import partial
+
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 from ops import conv, lrelu, conv2d_downscale2d, upscale2d_conv2d, blur2d, pixel_norm
 from ops import minibatch_stddev_layer
 

--- a/code/ops.py
+++ b/code/ops.py
@@ -19,9 +19,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
-from tricks import tf
 from functools import partial
+
 import numpy as np
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 
 lrelu = partial(tf.nn.leaky_relu, alpha=0.2)
 

--- a/code/train.py
+++ b/code/train.py
@@ -19,13 +19,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
-# Imports
-from tricks import tf
 import datetime
 import argparse
 from functools import partial
-import otbtf
 import logging
+
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+import otbtf
+ 
 from ops import downscale2d
 from vgg import compute_vgg_loss
 import network

--- a/code/train.py
+++ b/code/train.py
@@ -24,9 +24,9 @@ import argparse
 from functools import partial
 import logging
 
+import otbtf
 import tensorflow.compat.v1 as tf
 tf.disable_v2_behavior()
-import otbtf
  
 from ops import downscale2d
 from vgg import compute_vgg_loss

--- a/code/vgg.py
+++ b/code/vgg.py
@@ -19,9 +19,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
-from tricks import tf
 import logging
+
 import numpy as np
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 class Vgg19:
     """


### PR DESCRIPTION
To enable import of TFcompat v1 in SR4RS, after the removal of the tricks module from OTBTF